### PR TITLE
メニューボタンをSVG imgからCSSハンバーガーに変更

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -30,9 +30,11 @@
         <div x-data="{ open: false }" class="relative">
           <button @click="open = !open"
                   @keydown.escape.window="open = false"
-                  class="p-2 rounded-lg hover:bg-slate-100 transition-colors"
+                  class="p-2 rounded-lg hover:bg-slate-100 transition-colors flex flex-col justify-center gap-1.5 w-10 h-10"
                   aria-label="アカウントメニュー">
-            <img src="{% static 'img/menu-btn.svg' %}" alt="メニュー" class="w-6 h-6">
+            <span class="block w-5 h-0.5 bg-slate-700 mx-auto"></span>
+            <span class="block w-5 h-0.5 bg-slate-700 mx-auto"></span>
+            <span class="block w-5 h-0.5 bg-slate-700 mx-auto"></span>
           </button>
           <div x-show="open"
                @click.away="open = false"


### PR DESCRIPTION
## 変更内容

- メニューボタンの `<img src="menu-btn.svg">` を削除
- Tailwindの `<span>` 3つによるCSSのみのハンバーガーアイコンに差し替え

## 背景

既存のSVGは `fill-rule="evenodd"` で背景を塗りつぶし・3本線を「穴抜き」する構造だったため、白いナビバーと色が合わない問題があった。
CSSハンバーガーに替えることで `bg-slate-700` の線が白背景に対して正しく表示される。

## テスト

- [x] ブラウザでメニューボタンが3本線として表示されることを確認
- [x] ボタンクリックでドロップダウンメニューが開閉することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)