### PR TITLE
fix: 空送信時のjournal_init↔journal_over無限リダイレクトを修正

### DIFF
--- a/journal/templates/journal/journal_init.html
+++ b/journal/templates/journal/journal_init.html
@@ -26,6 +26,12 @@
 
   <div class="journal-divider"></div>
 
+  {% if error_message %}
+  <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-600">
+    {{ error_message }}
+  </div>
+  {% endif %}
+
   <form method="post">
     {% csrf_token %}
 

--- a/journal/views/home_journal.py
+++ b/journal/views/home_journal.py
@@ -203,23 +203,39 @@ class JournalInitView(LoginRequiredMixin, View):
         )
 
         if goal_formset.is_valid() and todo_formset.is_valid():
+            saved_count = 0
             # Goal 保存
             for goal in goal_formset.save(commit=False):
                 if goal.title:
                     goal.journal = journal
                     goal.save()
+                    saved_count += 1
             # Todo 保存
             for todo in todo_formset.save(commit=False):
                 if todo.title:
                     todo.journal = journal
                     todo.save()
+                    saved_count += 1
 
-            return redirect(
-                "journal:journal_over",
-                year=year,
-                month=month,
-                day=day
-            )
+            if saved_count > 0:
+                return redirect(
+                    "journal:journal_over",
+                    year=year,
+                    month=month,
+                    day=day
+                )
+
+            # 全て空の場合はエラーメッセージを表示して再表示
+            context = {
+                "journal": journal,
+                "goal_formset": goal_formset,
+                "todo_formset": todo_formset,
+                "prev_day": journal_date - timedelta(days=1),
+                "next_day": journal_date + timedelta(days=1),
+                "journal_date": journal_date,
+                "error_message": "目標またはTodoを少なくとも1つ入力してください。",
+            }
+            return render(request, self.template_name, context)
 
         # バリデーションエラーの場合は再表示
         context = {


### PR DESCRIPTION
## 概要
GoalとTodoを何も入力せずにjournal_initフォームを送信した際に発生する無限リダイレクトループを修正。

## 原因
`JournalInitView.post` で空入力をスキップしてGoal/Todoを1件も保存しなかった場合でも `journal_over` にリダイレクトしていた。`JournalOverView.get` 側でも空チェックがあるため `journal_init` に再リダイレクトされ、ループが発生していた。

## 修正箇所

### `journal/views/home_journal.py`
- 保存件数を `saved_count` でカウントするように変更
- `saved_count == 0`（Goal・Todo が全て空）の場合は `journal_over` にリダイレクトせず、`journal_init` をエラーメッセージとともに再表示するよう修正

### `journal/templates/journal/journal_init.html`
- `error_message` が渡された場合にエラーメッセージを表示するブロックを追加

## 関連 Issue
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)