### PR TITLE
fix: BaseCreateViewで空タイトルのGoal/Todoが保存される問題を修正

### DIFF
--- a/journal/views/base.py
+++ b/journal/views/base.py
@@ -58,6 +58,8 @@ class BaseCreateView(LoginRequiredMixin, View):
             objects = formset.save(commit=False)
 
             for obj in objects:
+                if not obj.title:
+                    continue
                 obj.journal = journal
                 obj.save()
 


### PR DESCRIPTION
## 概要
「+」作成画面でタイトル未入力のGoal/Todoが保存できてしまうバグを修正。

## 原因
`BaseCreateView.post` の保存ループに空タイトルをスキップする処理がなく、空のレコードが量産される状態だった。一方 `JournalInitView` は `if goal.title:` でスキップしており挙動が不統一だった。

## 修正箇所

### `journal/views/base.py`
- `BaseCreateView.post` の保存ループに `if not obj.title: continue` を追加
- タイトルが空のオブジェクトを保存せずスキップするよう修正し、`JournalInitView` と挙動を統一

## 関連 Issue
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)