### PR TITLE
fix: 入力フィールド追加ボタンで2つずつ追加される問題を修正 (#23)

### DIFF
--- a/journal/templates/journal/create_schedule.html
+++ b/journal/templates/journal/create_schedule.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block extra_js %}
+{{ block.super }}
 <script src="{% static 'js/timeset_rules.js' %}"></script>
 {% endblock %}
 {% block title %}スケジュールを作成{% endblock %}

--- a/journal/templates/journal/journal_init.html
+++ b/journal/templates/journal/journal_init.html
@@ -110,8 +110,8 @@
     </div>
   </form>
 </div>
+{% endblock %}
 
 {% block extra_js %}
 <script src="{% static 'js/journal_init.js' %}"></script>
-{% endblock %}
 {% endblock %}

--- a/templates/common/create_base.html
+++ b/templates/common/create_base.html
@@ -54,8 +54,8 @@
     </div>
   </section>
 </div>
+{% endblock %}
 
 {% block extra_js %}
 <script src="{% static 'js/create_formset.js' %}" defer></script>
-{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## 概要

入力フィールド追加ボタンを押すと1つではなく2つ追加される問題、およびスケジュール作成画面で追加ボタンが機能しない問題を修正。

## 原因と修正

### 1. フィールドが2つずつ追加される（`create_base.html` / `journal_init.html`）

`{% block extra_js %}` が `{% block content %}` の**内側**に定義されていたため、JSファイルが2箇所でレンダリングされ `DOMContentLoaded` リスナーが2重登録されていた。

```diff
-{% block extra_js %}
-<script src="..."></script>
-{% endblock %}
 {% endblock %}
+
+{% block extra_js %}
+<script src="..."></script>
+{% endblock %}
```

対象ファイル：
- `templates/common/create_base.html`
- `journal/templates/journal/journal_init.html`

### 2. スケジュール追加ボタンが機能しない（`create_schedule.html`）

`{% block extra_js %}` を `timeset_rules.js` だけで上書きしており、親テンプレート `create_base.html` の `create_formset.js` が読み込まれていなかった。`{{ block.super }}` を追加して両方読み込まれるよう修正。

```diff
 {% block extra_js %}
+{{ block.super }}
 <script src="{% static 'js/timeset_rules.js' %}"></script>
 {% endblock %}
```

## 動作確認リスト（Playwrightで確認済み）

- [x] `journal_init.html`（ジャーナル作成画面）でTodo/Goal追加ボタンを押すと**1つだけ**フィールドが増える
- [x] Todo Create画面で追加ボタンを押すと**1つだけ**フィールドが増える
- [x] Schedule Create画面で追加ボタンが機能し、**1つだけ**フィールドが増える
- [x] 複数回クリックしても毎回1つずつ正しく追加される
- [x] Goal / Reflection の各Create画面でも正常に動作する
- [x] 削除ボタンで入力フィールドが削除できる
- [x] フォーム送信が正常に動作する

Closes #23